### PR TITLE
us/mn/carlton missing street name in STREET column

### DIFF
--- a/sources/us/mn/carlton.json
+++ b/sources/us/mn/carlton.json
@@ -15,12 +15,7 @@
         "format": "geojson",
         "number": "ADDNUM",
         "unit": "Unit",
-        "street": [
-            "Pre_Dir",
-            "Street_Name",
-            "Suf_Type",
-            "Suf_Dir"
-        ],
+        "street": "StreetName",
         "city": "USPS_City",
         "postcode": "Zip5"
     }


### PR DESCRIPTION
StreetName had extra underscore.  Also removed street suffixes and prefixes because
they are now included in the StreetName.